### PR TITLE
Fix status being logged with debug mode false

### DIFF
--- a/lib/DynamicDNS.js
+++ b/lib/DynamicDNS.js
@@ -164,7 +164,7 @@ class DynamicDNS
             const hasChanged = (publicIP !== currentIP);
 
             // Log the current status.
-            console.log(`Public IP ${publicIP}, currentIP ${currentIP}, has change: ${hasChanged}`);
+            this.debug(`Public IP ${publicIP}, currentIP ${currentIP}, has change: ${hasChanged}`);
 
             // If they have changed or we are forced to do an update then update the hostname DNS IP address. Otherwise return true to indicate that all is well.
             return (hasChanged || force ? await this.update() : true);


### PR DESCRIPTION
The description for the debug mode option states:
> Set the debug mode on or off. The debug mode will write debug and status information to the console

But even when debug mode is set to `false`, the status information is still logged. This fixes that.